### PR TITLE
Pass Mapbox token to Pages build workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -96,6 +96,7 @@ jobs:
       - name: Build
         env:
           REPO_NAME: ${{ github.event.repository.name }}
+          VITE_MAPBOX_TOKEN: ${{ secrets.VITE_MAPBOX_TOKEN }}
         run: PATH_PREFIX=/$REPO_NAME pnpm build
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- pass the VITE_MAPBOX_TOKEN secret to the GitHub Pages build step so Vite embeds the Mapbox token during deployment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f0a47deeb88325bc12d23ab01b0719