### PR TITLE
Load Mapbox token at runtime for Vercel deployments

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -96,6 +96,7 @@ jobs:
       - name: Build
         env:
           REPO_NAME: ${{ github.event.repository.name }}
+          VITE_MAPBOX_TOKEN: ${{ secrets.VITE_MAPBOX_TOKEN }}
         run: PATH_PREFIX=/$REPO_NAME pnpm build
 
       - name: Upload artifact

--- a/api/mapbox-token.js
+++ b/api/mapbox-token.js
@@ -1,0 +1,10 @@
+export default function handler(request, response) {
+  const token = process.env.VITE_MAPBOX_TOKEN;
+
+  if (!token) {
+    response.status(404).json({ error: 'MAPBOX_TOKEN_NOT_CONFIGURED' });
+    return;
+  }
+
+  response.status(200).json({ token });
+}

--- a/src/components/RunMap/style.module.css
+++ b/src/components/RunMap/style.module.css
@@ -89,3 +89,13 @@
   background-position: center center;
   opacity: 1;
 }
+
+.mapPlaceholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  color: var(--color-primary);
+  background-color: var(--color-background);
+}
+


### PR DESCRIPTION
## Summary
- add a Vercel serverless API route that exposes the VITE_MAPBOX_TOKEN to the client at runtime
- lazily fetch the Mapbox token in the RunMap component and defer rendering the map until it is available
- style the loading placeholder shown while waiting for the token

## Testing
- pnpm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f0a47deeb88325bc12d23ab01b0719